### PR TITLE
refactor: register handler for post method only

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -38,6 +38,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     addServerHandler({
       route: '/api/__remote/:moduleId/:functionName',
+      method: 'post',
       handler: handlerPath
     })
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -11,13 +11,6 @@ export function createRemoteFnHandler<
   M extends keyof F,
 > (functions: F): EventHandler<any> {
   return eventHandler(async (event) => {
-    if (!isMethod(event, 'POST')) {
-      throw createError({
-        statusCode: 405,
-        statusMessage: `[nuxt-remote-fn]: method "${event.node.req.method}" is not allowed.`
-      })
-    }
-
     const body = await readBody(event)
     const { moduleId, functionName } = event.context.params as {
       moduleId: M

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,4 +1,4 @@
-import { eventHandler, isMethod, createError, readBody } from 'h3'
+import { eventHandler, createError, readBody } from 'h3'
 import { createContext } from 'unctx'
 import type { EventHandler, H3Event } from 'h3'
 


### PR DESCRIPTION
We can register the route handler with `method: 'post'` and let the route be registered automatically to accept POST method only. 

Side note: Exceptional well written module. It's amazing!