### PR TITLE
feat: createContext function

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export async function addTodo(todo: Todo) {
   const result = await prisma.todo.create({
     data: {
       ...todo,
-      userId: event.context.user.id
+      userId: user.id
     }
   })
 

--- a/README.md
+++ b/README.md
@@ -59,19 +59,30 @@ Checkout [the playground example](/playground).
 
 ## H3 Event
 
-The `useEvent` hook provides the `event` object of the current request:
+The `useEvent` hook provides the `event` object of the current request. You can use it to check headers, log requests, or extend the event's request object.
 
 ```ts
 import { useEvent } from 'nuxt-remote-fn/server'
+import { getRequestHeader, createError } from 'h3'
+import { decodeAndVerifyJwtToken } from '~/somewhere/in/utils'
 
 export async function addTodo(todo: Todo) {
   const event = useEvent()
+
+  const authorization = getRequestHeader(event, 'authorization')
+  const user = await decodeAndVerifyJwtToken(authorization.split(' ')[1])
+
+  if (!user) {
+    throw createError({ statusCode: 401 })
+  }
+
   const result = await prisma.todo.create({
     data: {
       ...todo,
       userId: event.context.user.id
     }
   })
+
   return result
 }
 ```

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "fast-glob": "^3.2.12",
     "h3": "^1.0.2",
     "ofetch": "^1.0.0",
-    "pathe": "^1.0.0",
-    "unctx": "^2.1.1"
+    "pathe": "^1.0.0"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^0.1.1",

--- a/playground/lib/todo.server.ts
+++ b/playground/lib/todo.server.ts
@@ -15,9 +15,6 @@ export function getTodo (id: number) {
 }
 
 export async function toggleTodo (id: number) {
-  const event = useEvent()
-  console.log(event.context.params)
-
   const todo = await getTodo(id)
   return prisma.todo.update({
     where: { id },
@@ -37,4 +34,9 @@ export function addTodo ({ title, content }: { title: string; content: string })
       completed: false
     }
   })
+}
+
+export function createContext() {
+  const event = useEvent()
+  // console.log('event.context.params', event.context.params)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,6 @@ specifiers:
   prisma: ^4.7.1
   taze: ^0.8.5
   tsx: ^3.12.1
-  unctx: ^2.1.1
 
 dependencies:
   '@nuxt/kit': 3.0.0
@@ -31,7 +30,6 @@ dependencies:
   h3: 1.0.2
   ofetch: 1.0.0
   pathe: 1.0.0
-  unctx: 2.1.1
 
 devDependencies:
   '@nuxt/eslint-config': 0.1.1_eslint@8.30.0

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,39 +1,45 @@
 import { eventHandler, createError, readBody } from 'h3'
-import { createContext } from 'unctx'
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { EventHandler, H3Event } from 'h3'
 
-const ctx = createContext<H3Event>()
+const DEFAULT_CONTEXT = {} as H3Event;
 
-export const useEvent = ctx.use
+const asyncLocalStorage = new AsyncLocalStorage<H3Event>();
+
+export function useEvent(): H3Event {
+  return asyncLocalStorage.getStore() || DEFAULT_CONTEXT;
+}
 
 export function createRemoteFnHandler<
   F extends Record<string, Record<string, () => any>>,
   M extends keyof F,
 > (functions: F): EventHandler<any> {
-  return eventHandler(async (event) => {
+  const handler = eventHandler(async (event) => {
     const body = await readBody(event)
     const { moduleId, functionName } = event.context.params as {
       moduleId: M
       functionName: keyof F[M]
     }
-
+  
     if (!(moduleId in functions)) {
       throw createError({
         statusCode: 400,
         statusMessage: `[nuxt-remote-fn]: Module ${moduleId as string} does not exist. Are you sure the file exists?`
       })
     }
-
+  
     if (typeof functions[moduleId][functionName] !== 'function') {
       throw createError({
         statusCode: 400,
         statusMessage: `[nuxt-remote-fn]: ${functionName as string} is not a function.`
       })
     }
+  
+    const result = functions[moduleId][functionName].apply(event, body.args)
+    return result
+  })
 
-    return ctx.call(event, () => {
-      const result = functions[moduleId][functionName].apply(event, body.args)
-      return result
-    })
+  return eventHandler((event) => {
+    return asyncLocalStorage.run(event, () => handler(event))
   })
 }

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -34,6 +34,10 @@ export function createRemoteFnHandler<
         statusMessage: `[nuxt-remote-fn]: ${functionName as string} is not a function.`
       })
     }
+
+    if ('createContext' in functions[moduleId]) {
+      await functions[moduleId]['createContext'].apply(event)
+    }
   
     const result = functions[moduleId][functionName].apply(event, body.args)
     return result


### PR DESCRIPTION
Adds a `createContext` function similar to tRPC's `createContext` that lets you manipulate the `event` object before running the remote function.