### PR TITLE
fix: invalid module ids

### DIFF
--- a/src/runtime/transformer.ts
+++ b/src/runtime/transformer.ts
@@ -4,8 +4,9 @@ import * as path from 'pathe'
 
 export function getModuleId (file: string) {
   const base = path.basename(file, path.extname(file)) // todo.server
-  const id = base.split('.')[0] // todo
-  return id
+  const id = base.split('.').slice(0,-1).join("_") // todo
+  const validId = id.replaceAll(/[^\p{L}\p{N}_$]/gu, '_').replace(/^\d/, '_$&')
+  return validId
 }
 
 interface Options {

--- a/test/transformer.test.ts
+++ b/test/transformer.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { getModuleId } from '../src/runtime/transformer'
+
+describe('transformer', () => {
+
+  it('receives a valid variable name for the module id', async () => {
+
+    expect(getModuleId('todo.server.ts')).toBe('todo')
+    expect(getModuleId('todo.prisma.server.ts')).toBe('todo_prisma')
+    expect(getModuleId('todo-todo.server.ts')).toBe('todo_todo')
+    expect(getModuleId('1-todo.server.ts')).toBe('_1_todo')
+  })
+})


### PR DESCRIPTION
Partially resolves https://github.com/wobsoriano/nuxt-remote-fn/issues/5

Replace invallid characters with an underscore
If the file starts with a number, add an underscore at the start

This fixes the issue for most cases, the module still breaks if
- The filename is a reserved word (debugger, default, function, ...)
- The same filename is used more than once in the project